### PR TITLE
fix: eslint interface reserved word error

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -5,7 +5,9 @@ module.exports = {
     },
     "extends": [
         "standard-with-typescript",
-        "plugin:vue/vue3-essential"
+        "plugin:vue/vue3-essential",
+        "@vue/eslint-config-typescript",
+        "@vue/eslint-config-prettier",
     ],
     "overrides": [
         {
@@ -20,12 +22,16 @@ module.exports = {
             }
         }
     ],
+    "parser":"vue-eslint-parser",
     "parserOptions": {
+        "parser": "@typescript-eslint/parser",
+        "extraFileExtensions": [".vue"],
         "ecmaVersion": "latest",
         "sourceType": "module"
     },
     "plugins": [
-        "vue"
+        "vue",
+        "@typescript-eslint"
     ],
     "rules": {
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
       },
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^6.14.0",
+        "@typescript-eslint/parser": "^6.14.0",
         "@vitejs/plugin-vue": "^4.5.0",
         "eslint": "^8.55.0",
         "eslint-config-standard-with-typescript": "^42.0.0",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^6.14.0",
+    "@typescript-eslint/parser": "^6.14.0",
     "@vitejs/plugin-vue": "^4.5.0",
     "eslint": "^8.55.0",
     "eslint-config-standard-with-typescript": "^42.0.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,6 +20,6 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.vue"],
+  "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.vue", "src/**/*.d.ts"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }


### PR DESCRIPTION
Before this fix ESLint throws an error about interfaces in vue components. Because it thinks we are using JS instead of TS.