### PR TITLE
fix: add geojson source which is not filter layer

### DIFF
--- a/src/store/map.ts
+++ b/src/store/map.ts
@@ -88,7 +88,7 @@ export const useMapStore = defineStore("map", () => {
 				data: geoJSONSrc
 			})
 		}
-		const addedSource = map.value.getSource(sourceType === "geojson" ? `drawn-${identifier}` : identifier);
+		const addedSource = map.value.getSource(sourceType === "geojson" ? isFilterLayer ? "drawn-"+identifier : identifier : identifier);
 		if (addedSource !== undefined) {
 			return addedSource as SourceSpecification;
 		} else {


### PR DESCRIPTION
when we adding geojson source which is not filter layer we check the wrong source name with "drawn-" prefix. This commits fix this issue