### PR TITLE
fix: manage multiple sidebars at the same position

### DIFF
--- a/src/components/BaseSidebarComponent.vue
+++ b/src/components/BaseSidebarComponent.vue
@@ -1,5 +1,5 @@
 <template>
-    <div ref="el" :class="sidebarPositionClass" :id="props.id" class="sidebar group flex grow-0 justify-between absolute rounded-lg p-1  lg:w-[300px] 2xl:w-[350px] 3xl:w-[400px] duration-1000" :style="props.style ? props.style : ''">
+    <div ref="el" :class="sidebarStatusClasses" :id="props.id" class="sidebar group flex grow-0 justify-between absolute rounded-lg p-1  lg:w-[300px] 2xl:w-[350px] 3xl:w-[400px] duration-1000" :style="props.style ? props.style : ''">
         <div class="header w-full flex group-[.sidebar-left]:flex-row-reverse group-[.sidebar-right]:flex-row group-[.sidebar-bottom]:flex-row-reverse p-1">
             <div class="close-button">
                 <Button @click="toggleSidebar">
@@ -36,14 +36,17 @@ will be higher than left and/or right component(s).
 interface Props {
     position: "left" | "right" | "bottom",
     id: string,
+    collapsed: boolean
     width?: string,
     height?: string,
     style?: string,
     bgColor?: string
 }
-const props = defineProps<Props>()
-const sidebarPositionClass = computed(() => {
-    return "sidebar-" + props.position
+const props = withDefaults(defineProps<Props>(), {
+    collapsed: true
+})
+const sidebarStatusClasses = computed(() => {
+    return `sidebar-${props.position} ${props.collapsed ? "collapsed":""}`
 })
 // to check width prop with css patterns (ends with 'px', 'vw' or '%')
 const widthRegex = /^(\d+(?:\.\d*)?)px$|^(\d+(?:\.\d*)?)vw$|^(\d+(?:\.\d*)?)%$/

--- a/src/core/helpers/sidebarControl.ts
+++ b/src/core/helpers/sidebarControl.ts
@@ -26,13 +26,27 @@ export class SidebarControl implements IControl {
             e.preventDefault()
             const sidebar: HTMLElement = document.getElementById(this._sidebarID)!
             if (sidebar !== null){
-                if (sidebar.classList.contains("collapsed")){
-                    sidebar.classList.remove("collapsed")
-                } else {
-                    sidebar.classList.add("collapsed")
+                const position = sidebar.dataset.position
+                if (position !== undefined){
+                    const alignedSidebars = document.querySelectorAll(`.sidebar-${position}`)
+                    if (alignedSidebars.length > 1){
+                        alignedSidebars.forEach(alignedSidebar => {
+                            if (alignedSidebar !== sidebar) {
+                                if (sidebar.classList.contains("collapsed")) {
+                                    alignedSidebar.classList.add("collapsed")
+                                }
+                            }
+                        })
+                    }
                 }
             }
-        });
+            if (sidebar.classList.contains("collapsed")){
+                sidebar.classList.remove("collapsed")
+            } else {
+                sidebar.classList.add("collapsed")
+            }
+        }
+        );
         return this._container;
     }
 


### PR DESCRIPTION
Currently, if multiple sidebars has same position, they open on top of each other. This causes a bug which you can't see or interact sidebar on the back. We fixed this situation with this commit