### PR TITLE
feat: Refactor addMapLayer function to use parameter objects 

### DIFF
--- a/src/components/Data/Layer/WorkspaceLayerListingItem.vue
+++ b/src/components/Data/Layer/WorkspaceLayerListingItem.vue
@@ -34,7 +34,7 @@ import Tag from "primevue/tag";
 import Button from "primevue/button"
 import InlineMessage from "primevue/inlinemessage";
 import { type GeoServerFeatureType, type GeoserverLayerInfo, type GeoserverLayerListItem, useGeoserverStore } from "@store/geoserver";
-import { type LayerStyleOptions, useMapStore } from "@store/map";
+import { type LayerParams, type LayerStyleOptions, useMapStore } from "@store/map";
 import Card from "primevue/card";
 import { isNullOrEmpty } from "../../../core/helpers/functions";
 import { useToast } from "primevue/usetoast";
@@ -110,17 +110,16 @@ function add2Map(): void{
             props.workspace,
             layerDetail.value).then(() => {
             if (!isNullOrEmpty(dataType) && !isNullOrEmpty(layerDetail.value)) {
-                mapStore.addMapLayer(
-                    "geoserver",
-                    layerDetail.value!.featureType.name,
-                    mapStore.geometryConversion(dataType.value),
-                    !isNullOrEmpty(layerStyling.value) ? { ...layerStyling.value }: undefined,
-                    layerDetail.value,
-                    `${layerDetail.value!.featureType.name}`,
-                    undefined,
-                    false,
-                    layerDetail.value?.featureType.title ?? undefined
-                ).then(()=>{
+                const layerParams: LayerParams = {
+                    sourceType:"geoserver",
+                    identifier:layerDetail.value!.featureType.name,
+                    layerType:mapStore.geometryConversion(dataType.value),
+                    layerStyle:!isNullOrEmpty(layerStyling.value) ? { ...layerStyling.value }: undefined,
+                    geoserverLayerDetails:layerDetail.value!,
+                    sourceLayer:`${layerDetail.value!.featureType.name}`,
+                    displayName:layerDetail.value?.featureType.title ?? undefined
+                }
+                mapStore.addMapLayer(layerParams).then(()=>{
                 }).catch(error => {
                     toast.add({ severity: "error", summary: "Error", detail: error, life: 3000 });
                 })

--- a/src/components/Participation/ParticipationForm.vue
+++ b/src/components/Participation/ParticipationForm.vue
@@ -49,7 +49,7 @@ import ParticipationDraw from "./ParticipationDraw.vue"
 import { ref } from "vue";
 import { useParticipationStore, type CenterLocation } from "@store/participation";
 import { type Feature, type FeatureCollection } from "geojson";
-import { useMapStore } from "@store/map";
+import { type LayerParams, useMapStore } from "@store/map";
 
 const mapStore = useMapStore()
 const participation = useParticipationStore()
@@ -99,18 +99,16 @@ function createFeedbackLayer(): void{
         features:[]
     }
     mapStore.addMapDataSource("geojson", "feedbackLayer", false, undefined, undefined, src).then(()=>{
-        mapStore.addMapLayer(
-            "geojson",
-            "feedbackLayer",
-            "circle",
-            layerStylePoint,
-            undefined,
-            undefined,
-            src,
-            false,
-            "Feedbacks",
-            undefined,
-            true).then(()=>{}).catch((error)=>{
+        const layerParams: LayerParams = {
+            sourceType:"geojson",
+            identifier:"feedbackLayer",
+            layerType:"circle",
+            layerStyle:layerStylePoint,
+            geoJSONSrc:src,
+            isFilterLayer:false,
+            displayName:"Feedbacks",
+        }
+        mapStore.addMapLayer(layerParams).then(()=>{}).catch((error)=>{
             console.error(error)
         })
     }).catch((error)=>{

--- a/src/store/draw.ts
+++ b/src/store/draw.ts
@@ -1,7 +1,7 @@
 import { defineStore, acceptHMRUpdate } from "pinia"
 import { TerraDraw, TerraDrawLineStringMode, TerraDrawMapLibreGLAdapter, TerraDrawPointMode, TerraDrawPolygonMode, TerraDrawRectangleMode, TerraDrawSelectMode } from "terra-draw"
 import { ref } from "vue";
-import { useMapStore } from "./map";
+import { type LayerParams, useMapStore } from "./map";
 import { type Map } from "maplibre-gl"
 import { type Feature, type FeatureCollection } from "geojson";
 import { useToast } from "primevue/usetoast";
@@ -136,16 +136,15 @@ export const useDrawStore = defineStore("draw", () => {
                     undefined,
                     geoJsonSnapshot
                 ).then(() => {
-                    mapStore.addMapLayer(
-                        "geojson",
-                        processedLayerName,
-                        geomType,
-                        undefined,
-                        undefined,
-                        undefined,
-                        geoJsonSnapshot,
+                    const layerParams: LayerParams = {
+                        sourceType:"geojson",
+                        identifier:processedLayerName,
+                        layerType:geomType,
+                        geoJSONSrc:geoJsonSnapshot,
                         isFilterLayer,
-                        layerName.value)
+                        displayName:layerName.value,
+                    }
+                    mapStore.addMapLayer(layerParams)
                         .then(() => {
                             stopDrawMode()
                         }).catch(error => {

--- a/src/store/participation.ts
+++ b/src/store/participation.ts
@@ -1,7 +1,7 @@
 import { defineStore, acceptHMRUpdate } from "pinia";
 import { ref } from "vue";
 import { type FeatureCollection, type Feature } from "geojson";
-import { useMapStore } from "./map";
+import { type LayerParams, useMapStore } from "./map";
 import { type Map } from "maplibre-gl";
 import {
     TerraDraw,
@@ -109,20 +109,18 @@ export const useParticipationStore = defineStore("participation", () => {
                 features
             )
             .then(() => {
+                const layerParamsPolygon: LayerParams = {
+                    sourceType:"geojson",
+                    identifier:"selectedAreasTempLayer-polygon",
+                    layerType:"fill",
+                    layerStyle:layerStylePolygon,
+                    geoJSONSrc:features,
+                    isFilterLayer:false,
+                    sourceIdentifier:"selectedAreasTempLayer",
+                    showOnLayerList:false
+                }
                 mapStore
-                    .addMapLayer(
-                        "geojson",
-                        "selectedAreasTempLayer-polygon",
-                        "fill",
-                        layerStylePolygon,
-                        undefined,
-                        undefined,
-                        features,
-                        false,
-                        undefined,
-                        "selectedAreasTempLayer",
-                        false
-                    )
+                    .addMapLayer(layerParamsPolygon)
                     .then(() => {
                         mapStore.map.setFilter(
                             "selectedAreasTempLayer-polygon",
@@ -132,20 +130,18 @@ export const useParticipationStore = defineStore("participation", () => {
                     .catch((error) => {
                         console.error(error);
                     });
+                const layerParamsLine: LayerParams = {
+                    sourceType:"geojson",
+                    identifier:"selectedAreasTempLayer-line",
+                    layerType:"line",
+                    layerStyle:layerStyleLine,
+                    geoJSONSrc:features,
+                    isFilterLayer:false,
+                    sourceIdentifier:"selectedAreasTempLayer",
+                    showOnLayerList:false
+                }
                 mapStore
-                    .addMapLayer(
-                        "geojson",
-                        "selectedAreasTempLayer-line",
-                        "line",
-                        layerStyleLine,
-                        undefined,
-                        undefined,
-                        features,
-                        false,
-                        undefined,
-                        "selectedAreasTempLayer",
-                        false
-                    )
+                    .addMapLayer(layerParamsLine)
                     .then(() => {
                         mapStore.map.setFilter("selectedAreasTempLayer-line", [
                             "==",
@@ -156,20 +152,18 @@ export const useParticipationStore = defineStore("participation", () => {
                     .catch((error) => {
                         console.error(error);
                     });
+                const layerParamsPoint: LayerParams = {
+                    sourceType:"geojson",
+                    identifier:"selectedAreasTempLayer-point",
+                    layerType:"circle",
+                    layerStyle:layerStylePoint,
+                    geoJSONSrc:features,
+                    isFilterLayer:false,
+                    sourceIdentifier:"selectedAreasTempLayer",
+                    showOnLayerList:false
+                }
                 mapStore
-                    .addMapLayer(
-                        "geojson",
-                        "selectedAreasTempLayer-point",
-                        "circle",
-                        layerStylePoint,
-                        undefined,
-                        undefined,
-                        features,
-                        false,
-                        undefined,
-                        "selectedAreasTempLayer",
-                        false
-                    )
+                    .addMapLayer(layerParamsPoint)
                     .then(() => {
                         mapStore.map.setFilter("selectedAreasTempLayer-point", [
                             "==",
@@ -251,12 +245,16 @@ export const useParticipationStore = defineStore("participation", () => {
         // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
         if (!mapStore.map.getSource("centerSelectionLayer")) {
             mapStore.addMapDataSource("geojson", "centerSelectionLayer", false, undefined, undefined, src).then(()=>{
-                mapStore.addMapLayer(
-                    "geojson",
-                    "centerSelectionLayer",
-                    "circle",
-                    layerStylePoint,
-                    undefined, undefined, src, false, undefined, undefined, false).then(()=>{}).catch((error)=>{
+                const layerParams: LayerParams = {
+                    sourceType:"geojson",
+                    identifier:"centerSelectionLayer",
+                    layerType:"circle",
+                    layerStyle:layerStylePoint,
+                    geoJSONSrc:src,
+                    isFilterLayer:false,
+                    showOnLayerList:false
+                }
+                mapStore.addMapLayer(layerParams).then(()=>{}).catch((error)=>{
                     console.error(error)
                 })
             }).catch((error)=>{

--- a/src/views/ParticipationView.vue
+++ b/src/views/ParticipationView.vue
@@ -6,7 +6,7 @@
 import { onMounted } from "vue";
 import ParticipationSidebar from "../components/Participation/ParticipationSidebar.vue"
 import sidebarConfig from "../configurations/sidebars"
-import { useMapStore } from "../store/map"
+import { type LayerParams, useMapStore } from "../store/map"
 import { type GeoserverLayerListItem, useGeoserverStore } from "../store/geoserver";
 import { useToast } from "primevue/usetoast";
 import { isNullOrEmpty } from "../core/helpers/functions";
@@ -42,17 +42,15 @@ onMounted(() => {
                         workspace,
                         detail).then(() => {
                         if (!isNullOrEmpty(dataType) && !isNullOrEmpty(detail)) {
-                            mapStore.addMapLayer(
-                                "geoserver",
-                                detail.featureType.name,
-                                mapStore.geometryConversion(dataType),
-                                undefined,
-                                detail,
-                                `${detail.featureType.name}`,
-                                undefined,
-                                false,
-                                detail?.featureType.title ?? undefined
-                            ).then(() => {
+                            const layerParams: LayerParams = {
+                                sourceType:"geoserver",
+                                identifier:detail.featureType.name,
+                                layerType:mapStore.geometryConversion(dataType),
+                                geoserverLayerDetails:detail,
+                                sourceLayer:`${detail.featureType.name}`,
+                                displayName:detail?.featureType.title ?? undefined
+                            }
+                            mapStore.addMapLayer(layerParams).then(() => {
                                 console.log(mapStore.map.getStyle().layers)
                             }).catch(error => {
                                 toast.add({ severity: "error", summary: "Error", detail: error, life: 3000 });


### PR DESCRIPTION

- Created BaseLayerParams interface for common layer parameters
- Defined GeoJSONLayerParams and GeoServerLayerParams interfaces extending BaseLayerParams
- Updated addMapLayer function to accept a single parameter object instead of multiple parameters
- Updated JSDoc comments to reflect the new parameter object structure
- Enhanced type safety and clarity by distinguishing between GeoJSON and GeoServer layer requirements